### PR TITLE
Bump Go version to 1.24.4

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,7 @@ FROM debian AS base
 
 ARG ruby_install_version="v0.10.1"
 ARG chruby_version="v0.3.9"
-ARG golang_version="go1.24.3"
+ARG golang_version="go1.24.4"
 
 #####
 # Base packages


### PR DESCRIPTION
This commit updates the Go version used in the Docker image to the latest version (1.24.4).

The following files were modified:
- Dockerfile.base: Updated the golang_version ARG to 1.24.4.